### PR TITLE
Fix to issue #17 : Skipping some test cases if there is no internet connection.

### DIFF
--- a/tests/testthat/test-get_headlines.R
+++ b/tests/testthat/test-get_headlines.R
@@ -2,6 +2,9 @@ test_that("get_headlines returns a data frame with one column", {
   # adding a small time delay to avoid simultaneous posts to the api
   Sys.sleep(3)
 
+  # Skip if the website could not be loaded
+  skip_if_offline("ycombinator.com")
+
   # Get the news
   output_headlines <- get_headlines("ycombinator.com")
 

--- a/tests/testthat/test-get_news.R
+++ b/tests/testthat/test-get_news.R
@@ -2,11 +2,17 @@ test_that("get_news returns a tibble with feed contents", {
   # adding a small time delay to avoid simultaneous posts to the api
   Sys.sleep(3)
 
+  # Skip if the website could not be loaded
+  skip_if_offline("ycombinator.com")
+
   # Get the news
   output_news <- get_news("ycombinator.com")
 
   # What's returned
   expect_s3_class(output_news, "data.frame")
+
+  # Skip if the website could not be loaded
+  skip_if_offline("bbc.com")
 
   # Get the news
   output_news <- get_news("bbc.com", topic = "travel")


### PR DESCRIPTION
As stated in #17 , some test cases required an internet connection, to avoid an incorrect fail.
I added `testthat::skip_if_online` in these test cases.

To check this behavior, run `devtools::test()` with and without internet connection.